### PR TITLE
Updated build scripts, toml etc.

### DIFF
--- a/crates/c-api/Cargo.toml
+++ b/crates/c-api/Cargo.toml
@@ -6,6 +6,7 @@ license.workspace = true
 edition = "2021"
 rust-version = "1.67.1"
 workspace = "../.."
+build = "dll-version/build.rs"
 
 [lib]
 name = "resvg_rhino"

--- a/crates/c-api/dll-version/build.rs
+++ b/crates/c-api/dll-version/build.rs
@@ -1,0 +1,24 @@
+fn main() {
+    let target = std::env::var("TARGET").unwrap();
+    if target.contains("windows") {
+        let rc_path = "dll-version/version.rc";
+        let include_paths = [
+            "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\um",
+            "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\shared",
+            "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\winrt",
+            "C:\\Program Files (x86)\\Windows Kits\\10\\Include\\10.0.26100.0\\ucrt",
+        ];
+        let include_combined = include_paths.join(";");
+
+        let out_dir = std::env::var("OUT_DIR").unwrap();
+        let output = std::process::Command::new("rc.exe")
+            .env("INCLUDE", include_combined)
+            .args(["/fo", &format!("{}/version.res", out_dir), rc_path])
+            .status()
+            .expect("Failed to run rc.exe");
+        assert!(output.success(), "rc.exe failed");
+
+        // println!("cargo:rustc-link-arg=/DEF:{}", "your.def"); // optional
+        println!("cargo:rustc-link-arg={}/version.res", out_dir);
+    }
+}

--- a/crates/c-api/dll-version/version.rc
+++ b/crates/c-api/dll-version/version.rc
@@ -1,0 +1,29 @@
+#include <winver.h>
+
+1 VERSIONINFO
+FILEVERSION     9,0,25170,01000
+PRODUCTVERSION  9,0,25170,01000
+FILEFLAGSMASK   VS_FFI_FILEFLAGSMASK
+FILEFLAGS       0
+FILEOS          VOS__WINDOWS32
+FILETYPE        VFT_DLL
+FILESUBTYPE     0
+BEGIN
+    BLOCK "StringFileInfo"
+    BEGIN
+        BLOCK "040904B0" // Language and code page
+        BEGIN
+            VALUE "CompanyName",      "resvg"
+            VALUE "FileDescription",  "resvg"
+            VALUE "FileVersion",      "9,0,25170,01000"
+            VALUE "InternalName",     "resvg_rhino.dll"
+            VALUE "OriginalFilename", "resvg_rhino.dll"
+            VALUE "ProductName",      "resvg"
+            VALUE "ProductVersion",   "9,0,25170,01000"
+        END
+    END
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 1200
+    END
+END


### PR DESCRIPTION
# Dll-version
- Installers need a dll version
- This script adds version info after the build
TODO : Script needs to be more flexible!